### PR TITLE
Update Zappi2PVOutput.ps1

### DIFF
--- a/Zappi2PVOutput.ps1
+++ b/Zappi2PVOutput.ps1
@@ -141,7 +141,7 @@
     $PVORequestBody.v4 = $PowerUsed.ToString()
 
     # Supply voltage is part of the data returned and is optional information to be uploaded, so include it:
-    $PVORequestBody.v6 = $ZappiStatus.zappi.vol.ToString()
+    $PVORequestBody.v6 = ($ZappiStatus.zappi.vol/10).ToString()
 
     # First check we haven't uploaded a status with this timestamp before
     if (-not (select-string -Pattern "Uploading status data for $($ZappiDateTime.ToString()) succeeded" -Path $UploadLog))


### PR DESCRIPTION
Myenergi changed the web service to provide supply voltage in decivolts instead of volts. This resulted in the supply voltage figures being uploaded to pvoutput.org being 10x too high. This code change first divides the voltage figure received from myenergi by 10 before uploading it.